### PR TITLE
[FEAT]: 차량관리 페이지 헤더, 검색 및 차량등록 영역 컴포넌트 구현 / Lucide 아이콘 의존성 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-select": "^2.2.5",
+    "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.525.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Navbar from "./Components/Navbar.tsx";
 import Home from "./Pages/Home/Home.tsx";
-import Management from "./Pages/Management.tsx";
+import Management from "./Pages/Management/Management.tsx";
 import DrivingLog from "./Pages/DrivingLog.tsx";
 import LocationSearch from "./Pages/LocationSearch.tsx";
 

--- a/src/Components/AddCarButton.tsx
+++ b/src/Components/AddCarButton.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { Button } from "@/Components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/Components/ui/dialog"
+import { Input } from "@/Components/ui/input"
+import { Label } from "@/Components/ui/label"
+import { Plus } from "lucide-react"
+
+export function AddCarButton({ text="차량 등록" } : {text?: String | null}) {
+  const [openFirst, setOpenFirst] = useState(false);
+  const [openSecond, setOpenSecond] = useState(false);
+  const [carNum, setCarNum] = useState("");
+  const [modelName, setModelName] = useState("");
+
+  return (
+    <>
+      <Dialog open={openFirst} onOpenChange={setOpenFirst}>
+        <form>
+          <DialogTrigger asChild>
+            <Button
+              className="bg-[#8D99FF] gap-3 hover:bg-[#8D99FF]/80"
+              onClick={() => setOpenFirst(true)}
+            >
+              <Plus strokeWidth={3} size={20}/>{text}
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-[425px]">
+            <DialogHeader>
+              <DialogTitle>신규차량 등록하기</DialogTitle>
+              <DialogDescription>
+                새 차량을 등록하기 위해 아래의 정보를 입력해 주세요
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4">
+              <div className="grid gap-3">
+                <Label htmlFor="carNum">차량 번호</Label>
+                <Input 
+                  id="carNum" 
+                  name="carNum" 
+                  placeholder="예: 34나3434" 
+                  className="placeholder:text-[#ACACAC]" 
+                  value={carNum}
+                  onChange={(e) => setCarNum(e.target.value)}
+                />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="modelName">차량명</Label>
+                <Input
+                 id="modelName" 
+                 name="modelName" 
+                 placeholder="예: Genesis GV80" 
+                 className="placeholder:text-[#ACACAC]"
+                 value={modelName}
+                 onChange={(e) => setModelName(e.target.value)}
+                 />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                className="bg-[#8D99FF] gap-3 hover:bg-[#8D99FF]/80"
+                onClick={() => {
+                  setOpenFirst(false);
+                  setOpenSecond(true);
+                }}
+              >
+                입력 완료
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </form>
+      </Dialog>
+      <Dialog open={openSecond} onOpenChange={setOpenSecond}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>차량 정보를 확인해 주세요</DialogTitle>
+            <DialogDescription>
+              <ul>
+                <li>차량 번호: {carNum}</li>
+                <li>차량명: {modelName}</li>
+              </ul>
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              className="bg-[#8D99FF] gap-3 hover:bg-[#8D99FF]/80"
+              onClick={() => {
+                setOpenSecond(false);
+                setOpenFirst(true);
+              }}
+            >
+              다시 입력
+            </Button>
+            <DialogClose>
+              <Button
+               type="submit" 
+               className="bg-[#8D99FF] gap-3 hover:bg-[#8D99FF]/80"
+               onClick={()=>{}}>등록</Button>
+            </DialogClose>
+            
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/Components/DeleteButton.tsx
+++ b/src/Components/DeleteButton.tsx
@@ -1,0 +1,10 @@
+import { Button } from "@/Components/ui/button"
+import { Trash } from "lucide-react";
+
+export function DeleteButton() {
+  return (
+      <Button className="bg-[#FF4343] gap-3 hover:bg-[#FF4343]/80">
+        <Trash strokeWidth={3} size={20}/> 삭제
+      </Button>
+  )
+}

--- a/src/Components/SearchButton.tsx
+++ b/src/Components/SearchButton.tsx
@@ -1,0 +1,10 @@
+import { Button } from "@/Components/ui/button"
+import { Search } from "lucide-react";
+
+export function SearchButton() {
+  return (
+      <Button className="bg-[#000000] gap-3 hover:bg-[#000000]/80">
+        <Search strokeWidth={3} size={20} /> 검색
+      </Button>
+  )
+}

--- a/src/Components/SearchInput.tsx
+++ b/src/Components/SearchInput.tsx
@@ -1,0 +1,5 @@
+import { Input } from "@/Components/ui/input"
+
+export function SearchInput() {
+  return <Input type="carNum" placeholder="차량번호로 검색" className="bg-[#FAFAFA] placeholder:text-[#DCDCDC]"/>
+}

--- a/src/Components/StatusSelection.tsx
+++ b/src/Components/StatusSelection.tsx
@@ -1,0 +1,30 @@
+// import * as React from "react"
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/Components/ui/select"
+
+export function StatusSelect() {
+  return (
+    <div className="w-[110px]">
+    <Select>
+      <SelectTrigger className="px-3 py-4">
+        <SelectValue placeholder="현황"/>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectItem value="on">운행중</SelectItem>
+          <SelectItem value="off">미운행</SelectItem>
+          <SelectItem value="reform">점검중</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+    </div>
+    
+  )
+}

--- a/src/Components/ui/button.tsx
+++ b/src/Components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3 py-5",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/src/Components/ui/dialog.tsx
+++ b/src/Components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/Components/ui/input.tsx
+++ b/src/Components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/src/Components/ui/label.tsx
+++ b/src/Components/ui/label.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/Components/ui/select.tsx
+++ b/src/Components/ui/select.tsx
@@ -1,0 +1,183 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-4 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/Pages/Management.tsx
+++ b/src/Pages/Management.tsx
@@ -1,5 +1,0 @@
-function Management() {
-    return <h2>차량 관리 페이지</h2>;
-}
-
-export default Management;

--- a/src/Pages/Management/CarTableSection.tsx
+++ b/src/Pages/Management/CarTableSection.tsx
@@ -1,0 +1,7 @@
+export function CarTableSection() {
+    return (
+        <div>
+
+        </div>
+    );
+}

--- a/src/Pages/Management/HeaderSection.tsx
+++ b/src/Pages/Management/HeaderSection.tsx
@@ -1,0 +1,9 @@
+import { Wrench } from "lucide-react";
+
+export function HeaderSection() {
+  return (
+    <div className="text-4xl font-bold flex items-center gap-3">
+      <Wrench size={36}/> 차량 관리
+    </div>
+  );
+}

--- a/src/Pages/Management/Management.tsx
+++ b/src/Pages/Management/Management.tsx
@@ -1,0 +1,15 @@
+import { HeaderSection } from "./HeaderSection";
+import { SearchSection } from "./SearchSection";
+import { PaginationSection } from "./PaginationSection";
+import { CarTableSection } from "./CarTableSection";
+
+export default function Management() {
+    return (
+        <div>
+            <HeaderSection />
+            <SearchSection />
+            <CarTableSection />
+            <PaginationSection />
+        </div>
+    );
+}

--- a/src/Pages/Management/PaginationSection.tsx
+++ b/src/Pages/Management/PaginationSection.tsx
@@ -1,0 +1,7 @@
+export function PaginationSection() {
+    return (
+        <div>
+          
+        </div>
+    );
+}

--- a/src/Pages/Management/SearchSection.tsx
+++ b/src/Pages/Management/SearchSection.tsx
@@ -1,0 +1,17 @@
+import { SearchButton } from "@/Components/SearchButton";
+import { DeleteButton } from "@/Components/DeleteButton";
+import { StatusSelect } from "@/Components/StatusSelection";
+import { SearchInput } from "@/Components/SearchInput";
+import { AddCarButton } from "@/Components/AddCarButton";
+
+export function SearchSection() {
+    return (
+        <div>
+          <SearchInput/>
+          <StatusSelect/>
+          <SearchButton/>
+          <DeleteButton/>
+          <AddCarButton/>
+        </div>
+    );
+}


### PR DESCRIPTION
#28 
- 차량관리 페이지 헤더, 검색 및 차량등록 영역 컴포넌트 추가
- npm install lucide 명령어 실행 필요(아이콘 라이브러리)